### PR TITLE
Header & Chart Legend Styling

### DIFF
--- a/lib/svg_island_web/live/hex_downloads_live.ex
+++ b/lib/svg_island_web/live/hex_downloads_live.ex
@@ -273,11 +273,7 @@ defmodule SvgIslandWeb.HexDownloadsLive do
           stroke="blue"
         />
         <!-- end debug mode -->
-        <.chart_legend
-          value="Last 30 days, all versions"
-          x={@chart.dimensions.chart_width}
-          y={@chart.dimensions.header_height}
-        />
+        <.chart_legend value="Last 30 days, all versions" x={@chart.dimensions.chart_width} y={0} />
         <%= for %{label: label, background_line: background_line} <- @chart.y_label_coordinates do %>
           <text x={label.x} y={label.y} class={label.class}>
             <%= label.value %>
@@ -350,17 +346,16 @@ defmodule SvgIslandWeb.HexDownloadsLive do
     Enum.to_list(max_data_point..0//-step_by)
   end
 
-  attr :class, :string, default: "fill-slate-500 text-sm font-semibold"
+  attr :class, :string,
+    default: "fill-slate-500 text-sm font-semibold [dominant-baseline:hanging] [text-anchor:end]"
 
   attr :x, :integer, required: true
   attr :y, :integer, required: true
   attr :value, :string, required: true
-  attr :x_offset, :integer, default: 180
-  attr :y_offset, :integer, default: 5
 
   defp chart_legend(assigns) do
     ~H"""
-    <text x={@x - @x_offset} y={@y - @y_offset} class={@class}><%= @value %></text>
+    <text x={@x} y={@y} class={@class}><%= @value %></text>
     """
   end
 


### PR DESCRIPTION
<img width="845" alt="Screenshot 2023-08-02 at 9 50 23 PM" src="https://github.com/gridpoint-com/svg_island/assets/60719697/ee6a4506-6268-474f-bba5-5424345bb30a">

- Applies styling for the Downloads header
- Adds the chart legend as an svg text element
- Apply formatting
- Apply Tailwind sorting to classes