### PR TITLE
Live Chart Updates

### DIFF
--- a/lib/svg_island_web/live/hex_downloads_live.ex
+++ b/lib/svg_island_web/live/hex_downloads_live.ex
@@ -47,7 +47,25 @@ defmodule SvgIslandWeb.HexDownloadsLive do
     {:ok, socket}
   end
 
-  def handle_info({:chart_update, _updates}, socket) do
+  def handle_info({:chart_update, updates}, socket) do
+    socket =
+      case updates do
+        [update | remaining] ->
+          socket =
+            update(socket, :chart, fn chart ->
+              chart
+              |> Map.put(:dataset, chart.dataset ++ [update])
+              |> put_chart_line_coordinates()
+            end)
+
+          Process.send_after(self(), {:chart_update, remaining}, @chart_update_interval)
+
+          socket
+
+        [] ->
+          socket
+      end
+
     {:noreply, socket}
   end
 

--- a/lib/svg_island_web/live/hex_downloads_live.ex
+++ b/lib/svg_island_web/live/hex_downloads_live.ex
@@ -96,7 +96,8 @@ defmodule SvgIslandWeb.HexDownloadsLive do
     current_line_start_x = previous_line.line_end.x
     current_line_start_y = previous_line.line_end.y
 
-    current_line_end_x = scale_x_line_value(previous_line, chart)
+    distance_between_lines = 23
+    current_line_end_x = current_line_start_x + distance_between_lines
     current_line_end_y = scale_y_line_value(number_of_downloads, chart)
 
     percent_of_lines_drawn = Enum.count(line_coordinates) / Enum.count(chart.dataset)
@@ -118,12 +119,6 @@ defmodule SvgIslandWeb.HexDownloadsLive do
       }
       | line_coordinates
     ]
-  end
-
-  defp scale_x_line_value(previous_line, %Chart{dataset: dataset, dimensions: dimensions}) do
-    number_of_datapoints = Enum.count(dataset)
-    line_width = dimensions.chart_width / number_of_datapoints
-    previous_line.line_end.x + line_width
   end
 
   defp scale_y_line_value(value, %Chart{dataset: dataset, dimensions: dimensions}) do

--- a/lib/svg_island_web/live/hex_downloads_live.ex
+++ b/lib/svg_island_web/live/hex_downloads_live.ex
@@ -8,7 +8,17 @@ defmodule SvgIslandWeb.HexDownloadsLive do
   alias SvgIsland.Chart
   alias Phoenix.LiveView.JS
 
+  @chart_update_interval 2_000
+
   def mount(_params, _session, socket) do
+    if connected?(socket),
+      do:
+        Process.send_after(
+          self(),
+          {:chart_update, [20_000, 22_000, 80_000, 75_000, 70_000, 22_000]},
+          @chart_update_interval
+        )
+
     dimensions = %{
       viewbox_height: 210,
       viewbox_width: 800,
@@ -35,6 +45,10 @@ defmodule SvgIslandWeb.HexDownloadsLive do
       |> assign(:tooltip, nil)
 
     {:ok, socket}
+  end
+
+  def handle_info({:chart_update, _updates}, socket) do
+    {:noreply, socket}
   end
 
   def handle_event("show-tooltip", params, socket) do

--- a/lib/svg_island_web/live/hex_downloads_live.ex
+++ b/lib/svg_island_web/live/hex_downloads_live.ex
@@ -87,6 +87,8 @@ defmodule SvgIslandWeb.HexDownloadsLive do
 
     [
       %{
+        id:
+          "line-#{number_of_downloads}-#{first_line_start_x}-#{first_line_start_y}-#{first_line_end_x}-#{first_line_end_y}",
         line_start: %{
           x: first_line_start_x,
           y: first_line_start_y
@@ -120,6 +122,8 @@ defmodule SvgIslandWeb.HexDownloadsLive do
 
     [
       %{
+        id:
+          "line-#{number_of_downloads}-#{current_line_start_x}-#{current_line_start_y}-#{current_line_end_x}-#{current_line_end_y}",
         line_start: %{
           x: current_line_start_x,
           y: current_line_start_y
@@ -301,6 +305,7 @@ defmodule SvgIslandWeb.HexDownloadsLive do
         <% end %>
         <%= for %{line_start: line_start, line_end: line_end} = line <- @chart.line_coordinates do %>
           <.draw_monoline
+            id={line.id}
             line_start_x={line_start.x}
             line_start_y={line_start.y}
             line_end_x={line_end.x}
@@ -378,6 +383,7 @@ defmodule SvgIslandWeb.HexDownloadsLive do
     """
   end
 
+  attr :id, :string, default: ""
   attr :line_start_x, :integer, required: true
   attr :line_start_y, :integer, required: true
   attr :line_end_x, :integer, required: true
@@ -387,8 +393,11 @@ defmodule SvgIslandWeb.HexDownloadsLive do
   attr :on_click_event_params, :map, default: %{}
 
   defp draw_monoline(assigns) do
+    dbg(assigns.id)
+
     ~H"""
     <polyline
+      id={@id}
       points={"#{@line_start_x},#{@line_start_y} #{@line_end_x},#{@line_end_y}"}
       class={@class}
       phx-click={


### PR DESCRIPTION
Adds chart updating logic for both regular updates and stream updates

Please review by commit as it tells a story

You can checkout commit 4347081 (for example `git checkout 4347081`) for the regular update and see that every line is redrawn for each update

Then you can checkout commit ad53f8d for the stream update and see that only the new line is drawn for each update

We can use these commits to the make chart update gifs. Let me know if I can help out anyway.